### PR TITLE
Fix webhook validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.nightfall</groupId>
     <artifactId>scan-api</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>The Nightfall Scanner provides Java bindings for our developer platform, which allows clients

--- a/src/main/java/ai/nightfall/scan/WebhookSignatureValidator.java
+++ b/src/main/java/ai/nightfall/scan/WebhookSignatureValidator.java
@@ -52,6 +52,7 @@ public class WebhookSignatureValidator {
      *                         since the Unix epoch.
      * @return true if the signature is valid and the request occurred within the allowed time threshold,
      *      otherwise false.
+     * @throws NumberFormatException if <code>requestTime</code> is not parsable as an integer
      */
     public boolean validate(String requestBody, byte[] signingSecret, String requestSignature, String requestTime) {
         if (requestBody == null || signingSecret == null || requestSignature == null || requestTime == null) {
@@ -59,8 +60,8 @@ public class WebhookSignatureValidator {
         }
 
         Instant now = Instant.now();
-        Instant reqTime = Instant.parse(requestTime);
-        if (now.minus(this.threshold).isAfter(reqTime)) {
+        Instant reqTime = Instant.ofEpochSecond(Long.parseLong(requestTime));
+        if (now.minus(this.threshold).isAfter(reqTime) || reqTime.isAfter(now)) {
             return false;
         }
 

--- a/src/test/java/ai/nightfall/scan/WebhookSignatureValidatorTest.java
+++ b/src/test/java/ai/nightfall/scan/WebhookSignatureValidatorTest.java
@@ -17,10 +17,10 @@ public class WebhookSignatureValidatorTest {
 
     @Test
     public void testHappyPath() {
-        String timestamp = "2021-10-04T17:30:43.42Z";
+        String timestamp = "1633368643";
         String reqBody = "hello world foo bar goodnight moon";
         byte[] secret = "super-secret-shhhh".getBytes(StandardCharsets.UTF_8);
-        String expectedSignature = "45bf0200a2cbc02ae2595fcf9ba4a2b262d836672c4a26fc3300cc54353587cd";
+        String expectedSignature = "641ada412da02d7df7ca59e94a556b7f5683374db614565ad3d99da1a9a779fb";
 
         WebhookSignatureValidator validator = new WebhookSignatureValidator(reallyLongTime);
         boolean result = validator.validate(reqBody, secret, expectedSignature, timestamp);
@@ -29,10 +29,22 @@ public class WebhookSignatureValidatorTest {
 
     @Test
     public void testRequestTooOld() {
-        String timestamp = "2021-10-04T17:30:43.42Z";
+        String timestamp = "1633368643";
         String reqBody = "hello world foo bar goodnight moon";
         byte[] secret = "super-secret-shhhh".getBytes(StandardCharsets.UTF_8);
-        String expectedSignature = "45bf0200a2cbc02ae2595fcf9ba4a2b262d836672c4a26fc3300cc54353587cd";
+        String expectedSignature = "641ada412da02d7df7ca59e94a556b7f5683374db614565ad3d99da1a9a779fb";
+
+        WebhookSignatureValidator validator = new WebhookSignatureValidator(Duration.ofMinutes(1));
+        boolean result = validator.validate(reqBody, secret, expectedSignature, timestamp);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testRequestTooFarInTheFuture() {
+        String timestamp = "4789042243";
+        String reqBody = "hello world foo bar goodnight moon";
+        byte[] secret = "super-secret-shhhh".getBytes(StandardCharsets.UTF_8);
+        String expectedSignature = "641ada412da02d7df7ca59e94a556b7f5683374db614565ad3d99da1a9a779fb";
 
         WebhookSignatureValidator validator = new WebhookSignatureValidator(Duration.ofMinutes(1));
         boolean result = validator.validate(reqBody, secret, expectedSignature, timestamp);
@@ -41,7 +53,7 @@ public class WebhookSignatureValidatorTest {
 
     @Test
     public void testSignatureMismatch() {
-        String timestamp = "2021-10-04T17:30:43.42Z";
+        String timestamp = "1633368643";
         String reqBody = "hello world foo bar goodnight moon";
         byte[] secret = "super-secret-shhhh".getBytes(StandardCharsets.UTF_8);
         String incorrectSignature = "e05aa9a373d652b6a38fdb0e093cca3eca3d6dd803a50dbe8b98b137fd20fe87";


### PR DESCRIPTION
The webhook validator should consume the request timestamp as epoch seconds, not as an RFC3339 date string