### PR TITLE
Add support for default redaction config

### DIFF
--- a/src/main/java/ai/nightfall/scan/model/ScanTextConfig.java
+++ b/src/main/java/ai/nightfall/scan/model/ScanTextConfig.java
@@ -1,5 +1,6 @@
 package ai.nightfall.scan.model;
 
+import ai.nightfall.scan.model.redaction.RedactionConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -18,6 +19,9 @@ public class ScanTextConfig {
 
     @JsonProperty("contextBytes")
     private int contextBytes;
+
+    @JsonProperty("defaultRedactionConfig")
+    private RedactionConfig defaultRedactionConfig;
 
     /**
      * Create a scan configuration with the provided detection rules.
@@ -52,6 +56,22 @@ public class ScanTextConfig {
         this.detectionRuleUUIDs = detectionRuleUUIDs;
         this.detectionRules = detectionRules;
         this.contextBytes = contextBytes;
+    }
+
+    /**
+     * Create a scan configuration with the provided inline detection rules and detection rule UUIDs.
+     *
+     * @param detectionRuleUUIDs a list of detection rules to use to scan content (maximum length 10)
+     * @param detectionRules a list of detection rules to use to scan content (maximum length 10)
+     * @param contextBytes the number of bytes of context (leading and trailing) to return with any matched findings
+     * @param defaultRedactionConfig the default redaction configuration to apply to all detection rules
+     */
+    public ScanTextConfig(List<UUID> detectionRuleUUIDs, List<DetectionRule> detectionRules, int contextBytes,
+                          RedactionConfig defaultRedactionConfig) {
+        this.detectionRuleUUIDs = detectionRuleUUIDs;
+        this.detectionRules = detectionRules;
+        this.contextBytes = contextBytes;
+        this.defaultRedactionConfig = defaultRedactionConfig;
     }
 
     /**
@@ -108,12 +128,33 @@ public class ScanTextConfig {
         this.contextBytes = contextBytes;
     }
 
+    /**
+     * Get the default redaction configuration to-be-applied to all detection rules, unless a more specific redaction
+     * configuration is supplied at the detector level.
+     *
+     * @return the default redaction configuration
+     */
+    public RedactionConfig getDefaultRedactionConfig() {
+        return defaultRedactionConfig;
+    }
+
+    /**
+     * Set the default redaction configuration to-be-applied to all detection rules, unless a more specific redaction
+     * configuration is supplied at the detector level.
+     *
+     * @param defaultRedactionConfig the default redaction configuration
+     */
+    public void setDefaultRedactionConfig(RedactionConfig defaultRedactionConfig) {
+        this.defaultRedactionConfig = defaultRedactionConfig;
+    }
+
     @Override
     public String toString() {
         return "ScanTextConfig{"
                 + "detectionRuleUUIDs=" + detectionRuleUUIDs
                 + ", detectionRules=" + detectionRules
                 + ", contextBytes=" + contextBytes
+                + ", defaultRedactionConfig=" + defaultRedactionConfig
                 + '}';
     }
 }

--- a/src/test/java/ai/nightfall/scan/NightfallClientTest.java
+++ b/src/test/java/ai/nightfall/scan/NightfallClientTest.java
@@ -7,8 +7,11 @@ import ai.nightfall.scan.model.NightfallRequestTimeoutException;
 import ai.nightfall.scan.model.ScanFileRequest;
 import ai.nightfall.scan.model.ScanFileResponse;
 import ai.nightfall.scan.model.ScanPolicy;
+import ai.nightfall.scan.model.ScanTextConfig;
 import ai.nightfall.scan.model.ScanTextRequest;
 import ai.nightfall.scan.model.ScanTextResponse;
+import ai.nightfall.scan.model.redaction.RedactionConfig;
+import ai.nightfall.scan.model.redaction.SubstitutionConfig;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.Dispatcher;
@@ -24,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,9 +46,11 @@ public class NightfallClientTest {
         try (MockWebServer server = new MockWebServer()) {
             server.enqueue(new MockResponse().setBody("{\"findings\": [[]]}"));
 
-            List<List<Finding>> expectedFindings = Arrays.asList(Arrays.asList());
+            List<List<Finding>> expectedFindings = Arrays.asList(Collections.emptyList());
             NightfallClient c = new NightfallClient(getRequestURL(server), "key", 1, getHttpClient());
-            ScanTextRequest req = new ScanTextRequest(null, null);
+            RedactionConfig defRedCfg = new RedactionConfig(new SubstitutionConfig("REDACTED"));
+            ScanTextConfig cfg = new ScanTextConfig(Arrays.asList(UUID.fromString("c08c6c43-85ca-40e5-8f46-7d1cf1e176a3")), Collections.emptyList(), 20, defRedCfg);
+            ScanTextRequest req = new ScanTextRequest(null, cfg);
             ScanTextResponse resp = c.scanText(req);
             assertEquals(expectedFindings, resp.getFindings());
         } catch (IOException e) {


### PR DESCRIPTION
Plaintext scanning now supports a new field 'defaultRedactionConfig'. When set, this specifies how all findings should be redacted; this default configuration can be overridden at the detector level.