### PR TITLE
Add support for AlertConfig

### DIFF
--- a/src/main/java/ai/nightfall/scan/model/ScanPolicy.java
+++ b/src/main/java/ai/nightfall/scan/model/ScanPolicy.java
@@ -69,7 +69,6 @@ public class ScanPolicy {
      * @param detectionRules a list of detection rules to use to scan content. maximum length 10.
      * @param detectionRuleUUIDs a list of detection rule UUIDs to use to scan content. maximum length 10.
      */
-    @Deprecated
     public ScanPolicy(AlertConfig alertConfig, List<DetectionRule> detectionRules, List<UUID> detectionRuleUUIDs) {
         this.alertConfig = alertConfig;
         this.detectionRules = detectionRules;

--- a/src/main/java/ai/nightfall/scan/model/ScanPolicy.java
+++ b/src/main/java/ai/nightfall/scan/model/ScanPolicy.java
@@ -1,5 +1,6 @@
 package ai.nightfall.scan.model;
 
+import ai.nightfall.scan.model.alert.AlertConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -12,6 +13,7 @@ import java.util.UUID;
  */
 public class ScanPolicy {
 
+    @Deprecated
     @JsonProperty("webhookURL")
     private String webhookURL;
 
@@ -20,6 +22,9 @@ public class ScanPolicy {
 
     @JsonProperty("detectionRuleUUIDs")
     private List<UUID> detectionRuleUUIDs;
+
+    @JsonProperty("alertConfig")
+    private AlertConfig alertConfig;
 
     /**
      * Create a scan policy with the provided detection rules.
@@ -50,6 +55,7 @@ public class ScanPolicy {
      * @param detectionRules a list of detection rules to use to scan content. maximum length 10.
      * @param detectionRuleUUIDs a list of detection rule UUIDs to use to scan content. maximum length 10.
      */
+    @Deprecated
     public ScanPolicy(String webhookURL, List<DetectionRule> detectionRules, List<UUID> detectionRuleUUIDs) {
         this.webhookURL = webhookURL;
         this.detectionRules = detectionRules;
@@ -57,10 +63,25 @@ public class ScanPolicy {
     }
 
     /**
-     * Get the webhook URL.
+     * Create a scan policy with the provided detection rules and detection rule UUIDs.
+     *
+     * @param alertConfig the alert configuration that Nightfall will use to deliver findings to external sources.
+     * @param detectionRules a list of detection rules to use to scan content. maximum length 10.
+     * @param detectionRuleUUIDs a list of detection rule UUIDs to use to scan content. maximum length 10.
+     */
+    @Deprecated
+    public ScanPolicy(AlertConfig alertConfig, List<DetectionRule> detectionRules, List<UUID> detectionRuleUUIDs) {
+        this.alertConfig = alertConfig;
+        this.detectionRules = detectionRules;
+        this.detectionRuleUUIDs = detectionRuleUUIDs;
+    }
+
+    /**
+     * Get the webhook URL. Deprecated: use the <code>alertConfig</code> object instead.
      *
      * @return the webhook URL that Nightfall should deliver results to
      */
+    @Deprecated
     public String getWebhookURL() {
         return webhookURL;
     }
@@ -70,6 +91,7 @@ public class ScanPolicy {
      *
      * @param webhookURL the webhook URL that Nightfall should deliver results to
      */
+    @Deprecated
     public void setWebhookURL(String webhookURL) {
         this.webhookURL = webhookURL;
     }
@@ -109,4 +131,23 @@ public class ScanPolicy {
     public void setDetectionRuleUUIDs(List<UUID> detectionRuleUUIDs) {
         this.detectionRuleUUIDs = detectionRuleUUIDs;
     }
+
+    /**
+     * Get the alert configuration that specifies where alerts should be delivered when findings are detected.
+     *
+     * @return the alert configuration
+     */
+    public AlertConfig getAlertConfig() {
+        return alertConfig;
+    }
+
+    /**
+     * Sets the alert configuration that specifies where alerts should be delivered when findings are detected.
+     *
+     * @param alertConfig the alert configuration
+     */
+    public void setAlertConfig(AlertConfig alertConfig) {
+        this.alertConfig = alertConfig;
+    }
+
 }

--- a/src/main/java/ai/nightfall/scan/model/ScanTextConfig.java
+++ b/src/main/java/ai/nightfall/scan/model/ScanTextConfig.java
@@ -1,5 +1,6 @@
 package ai.nightfall.scan.model;
 
+import ai.nightfall.scan.model.alert.AlertConfig;
 import ai.nightfall.scan.model.redaction.RedactionConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -22,6 +23,9 @@ public class ScanTextConfig {
 
     @JsonProperty("defaultRedactionConfig")
     private RedactionConfig defaultRedactionConfig;
+
+    @JsonProperty("alertConfig")
+    private AlertConfig alertConfig;
 
     /**
      * Create a scan configuration with the provided detection rules.
@@ -148,6 +152,24 @@ public class ScanTextConfig {
         this.defaultRedactionConfig = defaultRedactionConfig;
     }
 
+    /**
+     * Get the alert configuration that specifies where alerts should be delivered when findings are detected.
+     *
+     * @return the alert configuration
+     */
+    public AlertConfig getAlertConfig() {
+        return alertConfig;
+    }
+
+    /**
+     * Sets the alert configuration that specifies where alerts should be delivered when findings are detected.
+     *
+     * @param alertConfig the alert configuration
+     */
+    public void setAlertConfig(AlertConfig alertConfig) {
+        this.alertConfig = alertConfig;
+    }
+
     @Override
     public String toString() {
         return "ScanTextConfig{"
@@ -155,6 +177,7 @@ public class ScanTextConfig {
                 + ", detectionRules=" + detectionRules
                 + ", contextBytes=" + contextBytes
                 + ", defaultRedactionConfig=" + defaultRedactionConfig
+                + ", alertConfig=" + alertConfig
                 + '}';
     }
 }

--- a/src/main/java/ai/nightfall/scan/model/ScanTextRequest.java
+++ b/src/main/java/ai/nightfall/scan/model/ScanTextRequest.java
@@ -1,5 +1,6 @@
 package ai.nightfall.scan.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -65,6 +66,8 @@ public class ScanTextRequest {
      *
      * @return the configuration to use to scan the <code>payload</code> data
      */
+    @JsonIgnore
+    @Deprecated
     public ScanTextConfig getConfig() {
         return getPolicy();
     }
@@ -83,6 +86,7 @@ public class ScanTextRequest {
      *
      * @param config the configuration to use to scan the <code>payload</code> data
      */
+    @Deprecated
     public void setConfig(ScanTextConfig config) {
         setPolicy(config);
     }

--- a/src/main/java/ai/nightfall/scan/model/alert/AlertConfig.java
+++ b/src/main/java/ai/nightfall/scan/model/alert/AlertConfig.java
@@ -1,0 +1,122 @@
+package ai.nightfall.scan.model.alert;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The AlertConfig class allows clients to specify where alerts should be delivered when findings are discovered as
+ * part of a scan. These alerts are delivered asynchronously to all destinations specified in the object instance.
+ */
+public class AlertConfig {
+
+    @JsonProperty("email")
+    private EmailAlert emailAlert;
+
+    @JsonProperty("slack")
+    private SlackAlert slackAlert;
+
+    @JsonProperty("url")
+    private WebhookAlert webhookAlert;
+
+    /**
+     * Build an instance of AlertConfig with all provided alert destinations.
+     *
+     * @param emailAlert the email alert destination
+     * @param slackAlert the Slack alert destination
+     * @param webhookAlert the webhook alert destination
+     */
+    public AlertConfig(EmailAlert emailAlert, SlackAlert slackAlert, WebhookAlert webhookAlert) {
+        this.emailAlert = emailAlert;
+        this.slackAlert = slackAlert;
+        this.webhookAlert = webhookAlert;
+    }
+
+    /**
+     * Build an instance of AlertConfig that sends findings alerts via webhook.
+     *
+     * @param webhookAlert the webhook alert destination
+     */
+    public AlertConfig(WebhookAlert webhookAlert) {
+        this.webhookAlert = webhookAlert;
+    }
+
+    /**
+     * Build an instance of AlertConfig that sends findings alerts via Slack.
+     *
+     * @param slackAlert the Slack alert destination
+     */
+    public AlertConfig(SlackAlert slackAlert) {
+        this.slackAlert = slackAlert;
+    }
+
+    /**
+     * Build an instance of AlertConfig that sends findings alerts via email.
+     *
+     * @param emailAlert the email alert destination
+     */
+    public AlertConfig(EmailAlert emailAlert) {
+        this.emailAlert = emailAlert;
+    }
+
+    /**
+     * Returns the email alert destination.
+     *
+     * @return the email alert destination
+     */
+    public EmailAlert getEmailAlert() {
+        return emailAlert;
+    }
+
+    /**
+     * Sets the email alert destination.
+     *
+     * @param emailAlert the email alert destination
+     */
+    public void setEmailAlert(EmailAlert emailAlert) {
+        this.emailAlert = emailAlert;
+    }
+
+    /**
+     * Returns the Slack alert destination.
+     *
+     * @return the Slack alert destination
+     */
+    public SlackAlert getSlackAlert() {
+        return slackAlert;
+    }
+
+    /**
+     * Sets the Slack alert destination.
+     *
+     * @param slackAlert the Slack alert destination
+     */
+    public void setSlackAlert(SlackAlert slackAlert) {
+        this.slackAlert = slackAlert;
+    }
+
+    /**
+     * Returns the webhook alert destination.
+     *
+     * @return the webhook alert destination
+     */
+    public WebhookAlert getWebhookAlert() {
+        return webhookAlert;
+    }
+
+    /**
+     * Sets the webhook alert destination.
+     *
+     * @param webhookAlert the webhook alert destination
+     */
+    public void setWebhookAlert(WebhookAlert webhookAlert) {
+        this.webhookAlert = webhookAlert;
+    }
+
+    @Override
+    public String toString() {
+        return "AlertConfig{"
+                + "emailAlert=" + emailAlert
+                + ", slackAlert=" + slackAlert
+                + ", webhookAlert=" + webhookAlert
+                + '}';
+    }
+}

--- a/src/main/java/ai/nightfall/scan/model/alert/EmailAlert.java
+++ b/src/main/java/ai/nightfall/scan/model/alert/EmailAlert.java
@@ -1,0 +1,48 @@
+package ai.nightfall.scan.model.alert;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The EmailAlert class contains the configuration required to allow clients to send an asynchronous email message
+ * when findings are detected. The findings themselves will be delivered as a file attachment on the email.
+ * Alerts are only sent if findings are detected.
+ */
+public class EmailAlert {
+
+    @JsonProperty("address")
+    private String address;
+
+    /**
+     * Creates an instance of the EmailAlert class with the provided email address.
+     *
+     * @param address an email address
+     */
+    public EmailAlert(String address) {
+        this.address = address;
+    }
+
+    /**
+     * Returns the email address to which alerts should be delivered.
+     *
+     * @return the email address
+     */
+    public String getAddress() {
+        return address;
+    }
+
+    /**
+     * Sets the email address to which alerts should be delivered.
+     *
+     * @param address the email address
+     */
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    @Override
+    public String toString() {
+        return "EmailAlert{"
+                + "address='" + address + '\''
+                + '}';
+    }
+}

--- a/src/main/java/ai/nightfall/scan/model/alert/SlackAlert.java
+++ b/src/main/java/ai/nightfall/scan/model/alert/SlackAlert.java
@@ -1,0 +1,51 @@
+package ai.nightfall.scan.model.alert;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The SlackAlert class contains the configuration required to allow clients to send asynchronous alerts to a
+ * Slack workspace when findings are detected. Note that in order for Slack alerts to be delivered to your workspace,
+ * you must use authenticate Nightfall to your Slack workspace under the Settings menu on the
+ * <a href="https://app.nightfall.ai/">Nightfall Dashboard</a>. Alerts are only sent if findings are detected.
+ *
+ * <p>Currently, Nightfall supports delivering alerts to public channels, formatted like "#general".
+ */
+public class SlackAlert {
+
+    @JsonProperty("target")
+    private String target;
+
+    /**
+     * Creates an instance of the SlackAlert class with the provided conversation name.
+     *
+     * @param target a Slack conversation name.
+     */
+    public SlackAlert(String target) {
+        this.target = target;
+    }
+
+    /**
+     * Returns the target conversation to which alerts should be delivered.
+     *
+     * @return the name of the target conversation
+     */
+    public String getTarget() {
+        return target;
+    }
+
+    /**
+     * Sets the target conversation to which alerts should be delivered.
+     *
+     * @param target the name of the target conversation
+     */
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    @Override
+    public String toString() {
+        return "SlackAlert{"
+                + "target='" + target + '\''
+                + '}';
+    }
+}

--- a/src/main/java/ai/nightfall/scan/model/alert/WebhookAlert.java
+++ b/src/main/java/ai/nightfall/scan/model/alert/WebhookAlert.java
@@ -1,0 +1,51 @@
+package ai.nightfall.scan.model.alert;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The WebhookAlert class contains the configuration required to allow clients to send a webhook event to an
+ * external URL when findings are detected. The URL provided must (1) use the HTTPS scheme, (2) have a
+ * route defined on the HTTP POST method, and (3) return a 200 status code upon receipt of the event.
+ *
+ * <p>In contrast to other platforms, when using the file scanning APIs, an alert is also sent to this webhook
+ * *even when there are no findings*.
+ */
+public class WebhookAlert {
+
+    @JsonProperty("address")
+    private String address;
+
+    /**
+     * Creates an instance of the WebhookAlert class with the provided URL.
+     *
+     * @param address a URL address
+     */
+    public WebhookAlert(String address) {
+        this.address = address;
+    }
+
+    /**
+     * Returns the URL address to which alerts should be delivered.
+     *
+     * @return the URL address
+     */
+    public String getAddress() {
+        return address;
+    }
+
+    /**
+     * Sets the URL address to which alerts should be delivered.
+     *
+     * @param address the URL address
+     */
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    @Override
+    public String toString() {
+        return "WebhookAlert{"
+                + "address='" + address + '\''
+                + '}';
+    }
+}


### PR DESCRIPTION
Callers may provide an alertConfig object as part of either a synchronous plaintext scan, or an asynchronous file scan to fan alerts out to any of { slack, email, and webhook}.