### PR TITLE
JsonIgnore and Deprecate scan request Config in favor of Policy.

### DIFF
--- a/src/main/java/ai/nightfall/scan/model/ScanTextRequest.java
+++ b/src/main/java/ai/nightfall/scan/model/ScanTextRequest.java
@@ -63,9 +63,10 @@ public class ScanTextRequest {
 
     /**
      * Get the request scan policy.
-     * @deprecated alias for <code>getPolicy</code>, just provided for backwards compatibility.
      *
      * @return the configuration to use to scan the <code>payload</code> data
+     *
+     * @deprecated alias for <code>getPolicy</code>, just provided for backwards compatibility.
      */
     @Deprecated
     @JsonIgnore
@@ -84,9 +85,10 @@ public class ScanTextRequest {
 
     /**
      * Set the request scan policy.
-     * @deprecated alias for <code>setPolicy</code>, just provided for backwards compatibility.
      *
      * @param config the configuration to use to scan the <code>payload</code> data
+     *
+     * @deprecated alias for <code>setPolicy</code>, just provided for backwards compatibility.
      */
     @Deprecated
     @JsonIgnore

--- a/src/main/java/ai/nightfall/scan/model/ScanTextRequest.java
+++ b/src/main/java/ai/nightfall/scan/model/ScanTextRequest.java
@@ -1,5 +1,6 @@
 package ai.nightfall.scan.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -61,10 +62,13 @@ public class ScanTextRequest {
     }
 
     /**
-     * Get the request scan policy. Same as <code>getPolicy</code>, just provided for backwards compatibility.
+     * Get the request scan policy.
+     * @deprecated alias for <code>getPolicy</code>, just provided for backwards compatibility.
      *
      * @return the configuration to use to scan the <code>payload</code> data
      */
+    @Deprecated
+    @JsonIgnore
     public ScanTextConfig getConfig() {
         return getPolicy();
     }
@@ -79,10 +83,13 @@ public class ScanTextRequest {
     }
 
     /**
-     * Set the request scan policy. Same as <code>setPolicy</code>, just provided for backwards compatibility.
+     * Set the request scan policy.
+     * @deprecated alias for <code>setPolicy</code>, just provided for backwards compatibility.
      *
      * @param config the configuration to use to scan the <code>payload</code> data
      */
+    @Deprecated
+    @JsonIgnore
     public void setConfig(ScanTextConfig config) {
         setPolicy(config);
     }


### PR DESCRIPTION
This was causing the server to return an error due to Jackson serializing both config and policy:

```
Exception in thread "main" NightfallAPIException{error=Error{code=40017, message='Invalid Request', description='InspectRequest.Config is deprecated and cannot be used with InspectRequest.Policy', additionalData={InspectRequest.Config=Cannot use InspectRequest.Policy in conjunction with InspectRequest.Config. Please use only InspectRequest.Policy., InspectRequest.Policy=Cannot use InspectRequest.Policy in conjunction with InspectRequest.Config. Please use only InspectRequest.Policy.}}, httpStatusCode=400}
	at ai.nightfall.scan.NightfallClient.issueRequest(NightfallClient.java:440)
	at ai.nightfall.scan.NightfallClient.scanText(NightfallClient.java:114)
	at main.Main.main(Main.java:40)
```