### PR TITLE
Fix hex conversion bug

### DIFF
--- a/src/main/java/ai/nightfall/scan/WebhookSignatureValidator.java
+++ b/src/main/java/ai/nightfall/scan/WebhookSignatureValidator.java
@@ -87,7 +87,7 @@ public class WebhookSignatureValidator {
     // as a minimum language level, here we are.
     String bytesToHex(byte[] in) {
         final StringBuilder builder = new StringBuilder();
-        for(byte b : in) {
+        for (byte b : in) {
             builder.append(String.format("%02x", b));
         }
         return builder.toString();

--- a/src/main/java/ai/nightfall/scan/WebhookSignatureValidator.java
+++ b/src/main/java/ai/nightfall/scan/WebhookSignatureValidator.java
@@ -3,7 +3,6 @@ package ai.nightfall.scan;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
-import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -80,7 +79,17 @@ public class WebhookSignatureValidator {
 
         String hashPayload = requestTime + ":" + requestBody;
         byte[] hashed = hmac.doFinal(hashPayload.getBytes(StandardCharsets.UTF_8));
-        String hexHash = String.format("%032x", new BigInteger(hashed));
+        String hexHash = bytesToHex(hashed);
         return hexHash.equals(requestSignature);
+    }
+
+    // Java 8-16 does not have a standard Hex converter class... so as long as this SDK supports Java 8
+    // as a minimum language level, here we are.
+    String bytesToHex(byte[] in) {
+        final StringBuilder builder = new StringBuilder();
+        for(byte b : in) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
     }
 }

--- a/src/test/java/ai/nightfall/scan/WebhookSignatureValidatorTest.java
+++ b/src/test/java/ai/nightfall/scan/WebhookSignatureValidatorTest.java
@@ -7,6 +7,7 @@ import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for the webhook signature validator module.
@@ -61,5 +62,27 @@ public class WebhookSignatureValidatorTest {
         WebhookSignatureValidator validator = new WebhookSignatureValidator(reallyLongTime);
         boolean result = validator.validate(reqBody, secret, incorrectSignature, timestamp);
         assertFalse(result);
+    }
+
+    @Test
+    public void testBytesToHex() {
+        byte[][] tests = new byte[][]{
+            new byte[]{-1, 1},
+            new byte[]{6, 12, 12, 24},
+            new byte[]{-14, -63, -34},
+            new byte[]{0, 1, 126, 127, -128, -127, -126, -3, -2, -1},
+        };
+        String[] expectedResults = new String[]{
+            "ff01",
+            "060c0c18",
+            "f2c1de",
+            "00017e7f808182fdfeff"
+        };
+
+        WebhookSignatureValidator validator = new WebhookSignatureValidator(reallyLongTime);
+        for (int i = 0; i < tests.length; i++) {
+            String actual = validator.bytesToHex(tests[i]);
+            assertEquals(expectedResults[i], actual);
+        }
     }
 }


### PR DESCRIPTION
Webhook signature validation is broken because of an error in the implementation of byte hex encoding.